### PR TITLE
add get listings fn

### DIFF
--- a/apps/frontend/gql/client.ts
+++ b/apps/frontend/gql/client.ts
@@ -1,0 +1,12 @@
+import { GraphQLClient } from 'graphql-request';
+import { getSdk } from './sdk.generated';
+
+const client = new GraphQLClient('http://localhost:42069/graphql', {
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+const sdk = getSdk(client);
+
+export default sdk;

--- a/apps/frontend/gql/requests/getListings.ts
+++ b/apps/frontend/gql/requests/getListings.ts
@@ -1,0 +1,10 @@
+import sdk from '../client';
+import { type Hex } from 'viem';
+
+export async function getListings({ channel }: { channel: Hex }) {
+  const { channels } = await sdk.listings({ channel });
+
+  return {
+    channels,
+  };
+}


### PR DESCRIPTION
Needs to be tested

Is the type of arg `channel` (Hex) compatible with what the gql query is expecting (String)? 

Currently the sdk returns `channels` but what we really want is listings, is this as simple as returning `channels: listings` when we're destructing things?