### PR TITLE
add generalized card component, add variant instances in estuary

### DIFF
--- a/apps/estuary-docs/app/estuary/components/card/page.tsx
+++ b/apps/estuary-docs/app/estuary/components/card/page.tsx
@@ -1,0 +1,38 @@
+import {
+  Flex,
+  Button,
+  BodySmall,
+  Add,
+  Headline,
+  Card,
+} from '@river/design-system';
+
+export default function Page() {
+  return (
+    <>
+      <Headline className='mb-8'>Card</Headline>
+      <Flex className='flex-col md:flex-row gap-10'>
+        {/* Default */}
+        <Flex className='flex-col gap-2'>
+          <BodySmall className='text-gray-400'>Default</BodySmall>
+          <Card size='default' className='bg-gray-100' />
+        </Flex>
+        {/* Icon */}
+        <Flex className='flex-col gap-2'>
+          <BodySmall className='text-gray-400'>Icon</BodySmall>
+          <Card size='icon' className='bg-gray-100' />
+        </Flex>
+        {/* Small */}
+        <Flex className='flex-col gap-2'>
+          <BodySmall className='text-gray-400'>Small</BodySmall>
+          <Card size='sm' className='bg-gray-100' />
+        </Flex>
+        {/* Large */}
+        <Flex className='flex-col gap-2'>
+          <BodySmall className='text-gray-400'>Large</BodySmall>
+          <Card size='lg' className='bg-gray-100' />
+        </Flex>
+      </Flex>
+    </>
+  );
+}

--- a/apps/estuary-docs/components/client/SideNav.tsx
+++ b/apps/estuary-docs/components/client/SideNav.tsx
@@ -37,6 +37,9 @@ export function SideNav() {
             <Link href='/estuary/components/button'>
               <BodySmall>Button</BodySmall>
             </Link>
+            <Link href='/estuary/components/card'>
+              <BodySmall>Card</BodySmall>
+            </Link>
           </Stack>
         </Stack>
       </ScrollArea.Viewport>

--- a/packages/design-system/src/components/Card.tsx
+++ b/packages/design-system/src/components/Card.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '../utils';
+
+const cardVariants = cva('aspect-square', {
+  variants: {
+    size: {
+      default: 'h-[224px] w-[224px] rounded',
+      sm: 'h-[160px] w-[160px] rounded',
+      lg: 'h-[248px] w-[248px] rounded-[6.5px]',
+      icon: 'h-[48px] w-[48px] rounded-[1.5px]',
+    },
+  },
+  defaultVariants: {
+    size: 'default',
+  },
+});
+
+interface CardProps
+  extends React.PropsWithChildren,
+    VariantProps<typeof cardVariants> {
+  className?: string;
+}
+
+function Card(props: CardProps) {
+  return (
+    <div
+      className={cn(
+        cardVariants({ size: props.size ?? 'default' }),
+        props.className
+      )}
+    >
+      {props.children}
+    </div>
+  );
+}
+
+Card.displayName = 'Card';
+
+export { Card, type CardProps };

--- a/packages/design-system/src/components/index.ts
+++ b/packages/design-system/src/components/index.ts
@@ -7,6 +7,7 @@ export {
   type TypographyProps,
 } from './Typography';
 export * from './Button';
+export * from './Card';
 export * from './Dialog';
 export * from './ContextMenu';
 export * from './DropdownMenu';


### PR DESCRIPTION
This component is a little tricky, cause for us to make use of it we'll still have to pass in an `Image` component as a child of the card. Going to see how this feels in practice, cause I think we won't be able to ignore the required props that come with the `Image` component.