### PR TITLE
Search UI refinements

### DIFF
--- a/apps/frontend/components/client/AddToChannelModal/states/search/SearchContainer.tsx
+++ b/apps/frontend/components/client/AddToChannelModal/states/search/SearchContainer.tsx
@@ -79,7 +79,7 @@ export function SearchContainer() {
 
   return (
     <Stack className='justify-center gap-4'>
-      <SearchGallery nftMetadata={searchResults} />
+      {searchResults && <SearchGallery nftMetadata={searchResults} />}
       <Stack className='gap-y-4 mx-[18px]'>
         <SearchInput
           searchResults={searchResults}
@@ -88,7 +88,7 @@ export function SearchContainer() {
         />
         <SearchAction
           nameOfAdd={searchResults?.title}
-          addReady={!!sendDataConfig ? true : false}
+          addReady={!!searchResults}
           addTrigger={sendData}
         />
       </Stack>

--- a/apps/frontend/gql/client.ts
+++ b/apps/frontend/gql/client.ts
@@ -1,7 +1,6 @@
 import { GraphQLClient } from 'graphql-request';
 import { getSdk } from './sdk.generated';
 
-
 const client = new GraphQLClient(
   process.env.NEXT_PUBLIC_GRAPHQL_API as string,
   {


### PR DESCRIPTION
1. 
**Problem:** When adding an nft to a Channel, `SearchContainer` displays an empty preview (`SearchGallery`) as soon as the `AddToChannelModal` opens. This is confusing as a user. Am I supposed to set the Title, Created By, etc?
**Solution:** Don't render the preview (`SearchGallery`) until we have a search result

before:
<img width="545" alt="Screen Shot 2023-09-14 at 1 32 42 PM" src="https://github.com/1ifeworld/river/assets/83888516/19fd63d6-1c47-4422-8e89-4a29892c97c0">

after:
<img width="483" alt="Screen Shot 2023-09-14 at 1 33 31 PM" src="https://github.com/1ifeworld/river/assets/83888516/27d7fe43-58ab-432b-a83e-51029706051b">
<img width="482" alt="Screen Shot 2023-09-14 at 1 33 47 PM" src="https://github.com/1ifeworld/river/assets/83888516/8f99912c-6ad6-4f81-8f35-b92124e965ef">


2.
**Problem:** In the same flow, the Add button should be disabled until we have a search result. Currently, we are checking the existence of `searchConfig` but it makes more sense to check for `searchResults`.
