### PR TITLE
add brightness reduction to channel and listing cards

### DIFF
--- a/apps/frontend/components/client/ChannelCard.tsx
+++ b/apps/frontend/components/client/ChannelCard.tsx
@@ -22,7 +22,7 @@ export function ChannelCard({
     <Stack className={cn('gap-y-2', className)}>
       {/* Image */}
       <Link href={`channel/${channel.id}`}>
-        <Card className='relative shadow-reg hover:brightness-50 transition-all'>
+        <Card className='relative shadow-reg hover:brightness-50 hover:bg-base transition-all'>
           <Image
             className='object-cover aspect-square'
             src={ipfsToHttps(channel.contractUri?.image as string)}

--- a/apps/frontend/components/client/ChannelCard.tsx
+++ b/apps/frontend/components/client/ChannelCard.tsx
@@ -1,30 +1,30 @@
-import Image from 'next/image'
-import Link from 'next/link'
-import { Body, Card, BodySmall, Stack, cn, Flex, C } from '@river/estuary'
-import { type Channel } from '@/gql'
-import { truncateText, ipfsToHttps } from '@/utils'
-import { useGetAddressDisplay } from '@/hooks'
-import { Hex } from 'viem'
+import Image from 'next/image';
+import Link from 'next/link';
+import { Body, Card, BodySmall, Stack, cn, Flex, C } from '@river/estuary';
+import { type Channel } from '@/gql';
+import { truncateText, ipfsToHttps } from '@/utils';
+import { useGetAddressDisplay } from '@/hooks';
+import { Hex } from 'viem';
 
 export function ChannelCard({
   channel,
   className,
 }: {
-  channel: Channel
-  className?: string
+  channel: Channel;
+  className?: string;
 }) {
   // Run useGetAddress hook on page load. Add in the display lag so that the cards dont jump
   // in place initially before display has fetched a value. always show at least the address,
   // and correct it to the ens. This should be replaced by a server side solution
-  const { display } = useGetAddressDisplay(channel.createdBy as Hex)
-  const frontEndDisplayLagFix = display ? display : (channel.createdBy as Hex)
+  const { display } = useGetAddressDisplay(channel.createdBy as Hex);
+  const frontEndDisplayLagFix = display ? display : (channel.createdBy as Hex);
   return (
     <Stack className={cn('gap-y-2', className)}>
       {/* Image */}
       <Link href={`channel/${channel.id}`}>
-        <Card className="relative shadow-reg">
+        <Card className='relative shadow-reg hover:brightness-50 transition-all'>
           <Image
-            className="object-cover aspect-square"
+            className='object-cover aspect-square'
             src={ipfsToHttps(channel.contractUri?.image as string)}
             alt={channel.contractUri?.name as string}
             fill
@@ -32,10 +32,10 @@ export function ChannelCard({
         </Card>
       </Link>
       {/* Caption */}
-      <Stack className="min-w-[224px]">
-        <Flex className="justify-between items-center">
+      <Stack className='min-w-[224px]'>
+        <Flex className='justify-between items-center'>
           <Link href={`channel/${channel.id}`}>
-            <Body className="text-label font-medium leading-[14px] hover:underline">
+            <Body className='text-label font-medium leading-[14px] hover:underline'>
               {truncateText(channel.contractUri?.name ?? '', 20)}
             </Body>
           </Link>
@@ -43,18 +43,18 @@ export function ChannelCard({
         </Flex>
         {(channel?.logicTransmitterMerkleAdmin[0].accounts?.length as number) >
         1 ? (
-          <BodySmall className="text-label-muted cursor-default">
+          <BodySmall className='text-label-muted cursor-default'>
             {truncateText(frontEndDisplayLagFix, 20)} +{' '}
             {(channel?.logicTransmitterMerkleAdmin[0].accounts
               ?.length as number) - 1}{' '}
             others
           </BodySmall>
         ) : (
-          <BodySmall className="text-label-muted cursor-default">
+          <BodySmall className='text-label-muted cursor-default'>
             {truncateText(frontEndDisplayLagFix, 30)}
           </BodySmall>
         )}
       </Stack>
     </Stack>
-  )
+  );
 }

--- a/apps/frontend/components/client/ListingCard.tsx
+++ b/apps/frontend/components/client/ListingCard.tsx
@@ -26,7 +26,7 @@ export function ListingCard({
   return (
     <Stack className={cn('gap-y-2', className)}>
       {/* Image */}
-      <Card className="relative shadow-reg">
+      <Card className="relative shadow-reg hover:brightness-50 transition-all">
         <Link
           href={`${extractAddressFromListingId(listing.id)}/${listing.id.slice(
             44,

--- a/apps/frontend/components/client/ListingCard.tsx
+++ b/apps/frontend/components/client/ListingCard.tsx
@@ -26,7 +26,7 @@ export function ListingCard({
   return (
     <Stack className={cn('gap-y-2', className)}>
       {/* Image */}
-      <Card className="relative shadow-reg hover:brightness-50 transition-all">
+      <Card className="relative shadow-reg hover:brightness-50 hover:bg-base transition-all">
         <Link
           href={`${extractAddressFromListingId(listing.id)}/${listing.id.slice(
             44,


### PR DESCRIPTION
I think the fact that the overlay doesn't extend to pngs is not a dealbreaker for including this, although it does bother me a bit. I'm also not convinced entirely that this should be the hover state for our cards, I'm kind of interested in what stripping the stroke would look like and adding that in on hover. 

As seen on the [Mirror](https://mirror.xyz/) explore page.

cc: @ioeylim 

Updated, saved by @0xTranqui `hover:bg-base` to deal with the pngs.