### PR TITLE
add saturn integration

### DIFF
--- a/apps/site/app/layout.tsx
+++ b/apps/site/app/layout.tsx
@@ -5,6 +5,7 @@ import { Toaster } from 'sonner'
 import '../styles/globals.css'
 import { fragmentMono } from './fonts/fonts'
 import { Providers } from './providers/providers'
+import Script from 'next/script'
 
 export const metadata: Metadata = {
   title: 'River',
@@ -33,6 +34,10 @@ export default function RootLayout({
           <Analytics />
         </Providers>
       </body>
+      <Script
+        async
+        src="https://saturn.tech/widget.js#integration=14b09943-4822-45b7-892d-a0150f577c33"
+      />
     </html>
   )
 }

--- a/apps/site/vercel.json
+++ b/apps/site/vercel.json
@@ -1,0 +1,8 @@
+{
+  "routes": [
+    {
+      "src": "/saturn-sw.js",
+      "dest": "https://saturn.tech/saturn-sw.js"
+    }
+  ]
+}


### PR DESCRIPTION
TL;DR of the Saturn stuff is we can speed up all of our content addressed media (except for video and audio, which we're leaving for Mux). They're in private beta we won't be charged for usage.

The way it works is by using a service worker, which is what this PR configures in our root layout, then sets up a reverse proxy for our domain. Essentially the service worker looks for requests with cids in them, and routes them to Saturn instead. If the request to Saturn fails, it just falls back to whatever link/gateway we've got set up, so no harm there.

I'm eager to see how effectively this speeds things up!