### PR TITLE
added rid check before processRegisterFor

### DIFF
--- a/apps/site/components/client/Header.tsx
+++ b/apps/site/components/client/Header.tsx
@@ -6,24 +6,26 @@ import { checkOwnerHasId } from 'lib/username'
 import { useState } from 'react'
 import { useParams } from 'next/navigation'
 
+
 export function Header() {
   const [open, setOpen] = useState<boolean>(false)
 
   const { ready, authenticated } = usePrivy()
-
   const { login } = useLogin({
     onComplete: async (user) => {
-      const ownerAddress = user?.wallet?.address
+      const ownerAddress = user?.wallet?.address;
       if (!ownerAddress) {
         setOpen(true)
       } else {
-        if (!(await checkOwnerHasId(ownerAddress)).exists) {
-
+        const checkDbResult = await checkOwnerHasId(ownerAddress)
+        if (!checkDbResult.exists) {
           setOpen(true)
+
         }
       }
     },
   })
+  
 
   const params = useParams()
 

--- a/apps/site/lib/username/checkUsernameAvailability.ts
+++ b/apps/site/lib/username/checkUsernameAvailability.ts
@@ -1,3 +1,8 @@
+import { idRegistryABI } from "scrypt"
+import { readContract } from "viem/_types/actions/public/readContract"
+import { optimismPubClient } from "@/config/publicClient"
+import { addresses } from "scrypt"
+import { Hex } from "viem"
 export interface CheckResponse {
   exists: boolean
 }
@@ -53,4 +58,16 @@ export async function checkOwnerHasId(owner: string): Promise<CheckResponse> {
     console.error('Error checking for owner:', error)
     throw error
   }
+}
+
+export async function checkOwnerHasRidInContract(owner: Hex) {
+
+  const rid = await optimismPubClient.readContract({
+    address: addresses.idRegistry.optimism,
+    abi: idRegistryABI,
+    functionName: 'idOf',
+    args: [owner]
+  } )
+
+  return rid
 }

--- a/apps/site/lib/username/setUsername.ts
+++ b/apps/site/lib/username/setUsername.ts
@@ -1,52 +1,63 @@
-import { Hex } from 'viem'
+  import { Hex } from 'viem'
 
-interface RegistrationParameters {
-  id: string
-  to?: string
-  owner: string
-  name: string
-  signature: string
-  timestamp: string
-}
-
-export async function setUsername({
-  userIdRegistered,
-  username,
-  registerForRecipient,
-  signature,
-  timestamp,
-  to,
-}: {
-  userIdRegistered: string
-  username: string
-  registerForRecipient: Hex
-  signature: Hex
-  timestamp: string
-  to?: string
-}) {
-  const requestBody: RegistrationParameters = {
-    id: userIdRegistered,
-    to: to || undefined,
-    owner: registerForRecipient,
-    name: username,
-    signature,
-    timestamp,
+  interface RegistrationParameters {
+    id: string
+    to?: string
+    owner: string
+    name: string
+    signature: string
+    timestamp: string
   }
 
-  await fetch(`${process.env.NEXT_PUBLIC_USERNAME_SERVICE}/set`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(requestBody),
-  })
-    .then((response) => response.json())
-    .then((data) => {
-      if (!data.success) {
-        console.error('Error:', data.error)
+  interface SetUsernameResponse {
+    success: boolean
+    data?: { username: string }
+    error?: string
+  }
+
+  export async function setUsername({
+    userIdRegistered,
+    username,
+    registerForRecipient,
+    signature,
+    timestamp,
+    to,
+  }: {
+    userIdRegistered: string
+    username: string
+    registerForRecipient: Hex
+    signature: Hex
+    timestamp: string
+    to?: string
+  }) : Promise<SetUsernameResponse> { 
+    const requestBody: RegistrationParameters = {
+      id: userIdRegistered,
+      to: to || undefined,
+      owner: registerForRecipient,
+      name: username,
+      signature,
+      timestamp,
+    };
+
+    try {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_USERNAME_SERVICE}/set`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestBody),
+      });
+  
+      const data = await response.json()
+  
+      if (response.ok && data.success) {
+        return { success: true, data: { username: data.username } }
+      } else {
+        return { success: false, error: data.error || 'An error occurred while setting the username.' };
       }
-    })
-    .catch((error) => {
-      console.error('Fetch error:', error)
-    })
-}
+    } catch (error) {
+      console.error('Fetch error:', error);
+      return { success: false, error: error instanceof Error ? error.message : 'An unknown error occurred.' };
+    }
+  }
+  


### PR DESCRIPTION
closes #425 

attempted to account for the scenario where:

users are not "new users" (have an embedded wallet) (!newUser)
have an RID on IdRegistry
but DO not have a username set in 'names' db (!username)

so we need to: 
set or update their username without pushing a tx as attempting to re-register with their embedded wallet would fail