### PR TITLE
adjust pagination controls location

### DIFF
--- a/apps/site/app/(base)/page.tsx
+++ b/apps/site/app/(base)/page.tsx
@@ -1,6 +1,6 @@
 import { Grid, Typography, Flex } from '@/design-system'
 import { getAllAdds } from '@/gql'
-import { ItemCard } from '@/server'
+import { ItemCard, Footer } from '@/server'
 import { ItemDropdown, PaginationControls } from '@/client'
 
 export default async function Home({
@@ -39,9 +39,10 @@ export default async function Home({
           ),
         )}
       </Grid>
-      <Flex className="pt-32 pb-8 justify-center">
+      <Flex className="gap-3 pt-32 pb-4 justify-center items-center flex-col md:flex-row">
         {/* @ts-ignore */}
         <PaginationControls pageInfo={pageInfo} />
+        <Footer />
       </Flex>
     </>
   )

--- a/apps/site/components/server/Footer.tsx
+++ b/apps/site/components/server/Footer.tsx
@@ -1,18 +1,28 @@
 import { Flex, Typography } from '@/design-system'
+import Link from 'next/link'
 
 export function Footer() {
   return (
-    <Flex className="gap-2 w-full justify-end py-3">
+    <Flex className="gap-2 w-full py-3 justify-center md:justify-end">
       <Typography className="text-muted-foreground items-center">
-        <span className="text-[14px] align-middle">&#169;</span> 2024 ·{' '}
         <a
           className="hover:text-primary-foreground transition-all"
           href="https://www.lifeworld.co"
           target="_blank"
           rel="noopener noreferrer"
         >
-          Lifeworld, Co.
+          Lifeworld
         </a>
+        <span className="px-1">·</span>
+        <Link
+          className="hover:text-primary-foreground"
+          href="/channel/bafyreihuskbd64blgyd6lkx7es4boxljbdqp3w5s5d2sym5ovbergxjlna"
+        >
+          Feedback
+        </Link>
+        <span className="px-1">·</span>
+        {/* Copyright symbol */}
+        <span className="text-[14px] align-middle">&#169;</span> river.ph, 2024
       </Typography>
     </Flex>
   )


### PR DESCRIPTION
What do you think about the location of the pagination controls on desktop? I think it solves the issue where previously both the controls centered relative to the cards and centered relative to the page looks weird.

cc: @ioeylim 

Also which routes should the footer extend to? Everything but the item view?

cc: @0xTranqui 