### PR TITLE
salief/channel page pagination

### DIFF
--- a/apps/site/app/channel/[id]/[index]/page.tsx
+++ b/apps/site/app/channel/[id]/[index]/page.tsx
@@ -44,6 +44,7 @@ export default async function ItemPage({
 }) {
   const { channel } = await getChannelWithId({
     id: params.id,
+    limit: 100,
   })
 
   const totalItems = channel?.adds?.items?.length ?? 0

--- a/apps/site/app/channel/[id]/page.tsx
+++ b/apps/site/app/channel/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { ViewToggle } from '@/client'
+import { ViewToggle, PaginationControls } from '@/client'
 import { Flex, Stack, Typography } from '@/design-system'
 import { getChannelWithId } from '@/gql'
 import { getAddsMetadata } from '@/lib'
@@ -17,8 +17,13 @@ export default async function Channel({
   params: { id: string }
   searchParams: { [key: string]: string | string[] | undefined }
 }) {
-  const { channel } = await getChannelWithId({
+  // biome-ignore lint:
+  const after = searchParams['after'] as string | undefined
+
+  const { channel, pageInfo } = await getChannelWithId({
     id: params.id,
+    limit: 100,
+    after,
   })
 
   if (!channel) {
@@ -57,6 +62,10 @@ export default async function Channel({
           </Stack>
         </div>
         <div className="hidden md:w-[3%] md:block">{}</div>
+      </Flex>
+      <Flex className="pt-32 pb-8 justify-center">
+        {/* @ts-ignore */}
+        <PaginationControls pageInfo={pageInfo} />
       </Flex>
     </section>
   )

--- a/apps/site/gql/queries/channelWithId.graphql
+++ b/apps/site/gql/queries/channelWithId.graphql
@@ -1,4 +1,4 @@
-query channelWithId($id: String!) {
+query channelWithId($id: String!, $limit: Int!, $after: String) {
   channel(id: $id) {
     id
     timestamp
@@ -13,7 +13,7 @@ query channelWithId($id: String!) {
         role
       }
     }
-    adds(limit: 100, orderBy: "timestamp", orderDirection: "desc") {
+    adds(limit: $limit, orderBy: "timestamp", orderDirection: "desc", after: $after) {
       items {
         timestamp
         channelId
@@ -34,6 +34,9 @@ query channelWithId($id: String!) {
             }
           }
         }
+      }
+      pageInfo {
+        ...PageInfo
       }
     }
   }

--- a/apps/site/gql/requests/getChannelWithId.ts
+++ b/apps/site/gql/requests/getChannelWithId.ts
@@ -2,12 +2,21 @@ import sdk from '../client'
 import { unstable_cache } from 'next/cache'
 
 export const getChannelWithId = unstable_cache(
-  async ({ id }: { id: string }) => {
+  async ({
+    id,
+    limit,
+    after,
+  }: { id: string; limit: number; after?: string }) => {
     const response = await sdk.channelWithId({
-      id: id,
+      id,
+      limit,
+      after,
     })
 
-    return { channel: response.channel }
+    return {
+      channel: response.channel,
+      pageInfo: response.channel?.adds?.pageInfo,
+    }
   },
   ['channelWithId'],
 )

--- a/apps/site/gql/sdk.generated.ts
+++ b/apps/site/gql/sdk.generated.ts
@@ -36,6 +36,8 @@ export type Adds = {
 };
 
 export type AddsFilter = {
+  AND?: InputMaybe<Array<InputMaybe<AddsFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<AddsFilter>>>;
   addedById?: InputMaybe<Scalars['BigInt']['input']>;
   addedById_gt?: InputMaybe<Scalars['BigInt']['input']>;
   addedById_gte?: InputMaybe<Scalars['BigInt']['input']>;
@@ -108,8 +110,8 @@ export type AddsFilter = {
 
 export type AddsPage = {
   __typename?: 'AddsPage';
-  items?: Maybe<Array<Adds>>;
-  pageInfo?: Maybe<PageInfo>;
+  items: Array<Adds>;
+  pageInfo: PageInfo;
 };
 
 export type Channel = {
@@ -134,7 +136,7 @@ export type ChannelAddsArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Scalars['String']['input']>;
   orderDirection?: InputMaybe<Scalars['String']['input']>;
-  timestamp?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<ChannelFilter>;
 };
 
 
@@ -144,7 +146,7 @@ export type ChannelRolesArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Scalars['String']['input']>;
   orderDirection?: InputMaybe<Scalars['String']['input']>;
-  timestamp?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<ChannelFilter>;
 };
 
 export type ChannelCounter = {
@@ -155,6 +157,8 @@ export type ChannelCounter = {
 };
 
 export type ChannelCounterFilter = {
+  AND?: InputMaybe<Array<InputMaybe<ChannelCounterFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<ChannelCounterFilter>>>;
   counter?: InputMaybe<Scalars['BigInt']['input']>;
   counter_gt?: InputMaybe<Scalars['BigInt']['input']>;
   counter_gte?: InputMaybe<Scalars['BigInt']['input']>;
@@ -185,11 +189,13 @@ export type ChannelCounterFilter = {
 
 export type ChannelCounterPage = {
   __typename?: 'ChannelCounterPage';
-  items?: Maybe<Array<ChannelCounter>>;
-  pageInfo?: Maybe<PageInfo>;
+  items: Array<ChannelCounter>;
+  pageInfo: PageInfo;
 };
 
 export type ChannelFilter = {
+  AND?: InputMaybe<Array<InputMaybe<ChannelFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<ChannelFilter>>>;
   createdById?: InputMaybe<Scalars['BigInt']['input']>;
   createdById_gt?: InputMaybe<Scalars['BigInt']['input']>;
   createdById_gte?: InputMaybe<Scalars['BigInt']['input']>;
@@ -260,8 +266,8 @@ export type ChannelFilter = {
 
 export type ChannelPage = {
   __typename?: 'ChannelPage';
-  items?: Maybe<Array<Channel>>;
-  pageInfo?: Maybe<PageInfo>;
+  items: Array<Channel>;
+  pageInfo: PageInfo;
 };
 
 export type ChannelRoles = {
@@ -275,6 +281,8 @@ export type ChannelRoles = {
 };
 
 export type ChannelRolesFilter = {
+  AND?: InputMaybe<Array<InputMaybe<ChannelRolesFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<ChannelRolesFilter>>>;
   channelId?: InputMaybe<Scalars['String']['input']>;
   channelId_contains?: InputMaybe<Scalars['String']['input']>;
   channelId_ends_with?: InputMaybe<Scalars['String']['input']>;
@@ -323,8 +331,8 @@ export type ChannelRolesFilter = {
 
 export type ChannelRolesPage = {
   __typename?: 'ChannelRolesPage';
-  items?: Maybe<Array<ChannelRoles>>;
-  pageInfo?: Maybe<PageInfo>;
+  items: Array<ChannelRoles>;
+  pageInfo: PageInfo;
 };
 
 export type Item = {
@@ -346,7 +354,7 @@ export type ItemAddsArgs = {
   limit?: InputMaybe<Scalars['Int']['input']>;
   orderBy?: InputMaybe<Scalars['String']['input']>;
   orderDirection?: InputMaybe<Scalars['String']['input']>;
-  timestamp?: InputMaybe<Scalars['Int']['input']>;
+  where?: InputMaybe<ItemFilter>;
 };
 
 export type ItemCounter = {
@@ -357,6 +365,8 @@ export type ItemCounter = {
 };
 
 export type ItemCounterFilter = {
+  AND?: InputMaybe<Array<InputMaybe<ItemCounterFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<ItemCounterFilter>>>;
   counter?: InputMaybe<Scalars['BigInt']['input']>;
   counter_gt?: InputMaybe<Scalars['BigInt']['input']>;
   counter_gte?: InputMaybe<Scalars['BigInt']['input']>;
@@ -387,11 +397,13 @@ export type ItemCounterFilter = {
 
 export type ItemCounterPage = {
   __typename?: 'ItemCounterPage';
-  items?: Maybe<Array<ItemCounter>>;
-  pageInfo?: Maybe<PageInfo>;
+  items: Array<ItemCounter>;
+  pageInfo: PageInfo;
 };
 
 export type ItemFilter = {
+  AND?: InputMaybe<Array<InputMaybe<ItemFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<ItemFilter>>>;
   createdById?: InputMaybe<Scalars['BigInt']['input']>;
   createdById_gt?: InputMaybe<Scalars['BigInt']['input']>;
   createdById_gte?: InputMaybe<Scalars['BigInt']['input']>;
@@ -442,8 +454,8 @@ export type ItemFilter = {
 
 export type ItemPage = {
   __typename?: 'ItemPage';
-  items?: Maybe<Array<Item>>;
-  pageInfo?: Maybe<PageInfo>;
+  items: Array<Item>;
+  pageInfo: PageInfo;
 };
 
 export type ItemRoles = {
@@ -456,6 +468,8 @@ export type ItemRoles = {
 };
 
 export type ItemRolesFilter = {
+  AND?: InputMaybe<Array<InputMaybe<ItemRolesFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<ItemRolesFilter>>>;
   id?: InputMaybe<Scalars['String']['input']>;
   id_contains?: InputMaybe<Scalars['String']['input']>;
   id_ends_with?: InputMaybe<Scalars['String']['input']>;
@@ -496,8 +510,8 @@ export type ItemRolesFilter = {
 
 export type ItemRolesPage = {
   __typename?: 'ItemRolesPage';
-  items?: Maybe<Array<ItemRoles>>;
-  pageInfo?: Maybe<PageInfo>;
+  items: Array<ItemRoles>;
+  pageInfo: PageInfo;
 };
 
 export type Message = {
@@ -511,6 +525,8 @@ export type Message = {
 };
 
 export type MessageFilter = {
+  AND?: InputMaybe<Array<InputMaybe<MessageFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<MessageFilter>>>;
   id?: InputMaybe<Scalars['String']['input']>;
   id_contains?: InputMaybe<Scalars['String']['input']>;
   id_ends_with?: InputMaybe<Scalars['String']['input']>;
@@ -567,8 +583,8 @@ export type MessageFilter = {
 
 export type MessagePage = {
   __typename?: 'MessagePage';
-  items?: Maybe<Array<Message>>;
-  pageInfo?: Maybe<PageInfo>;
+  items: Array<Message>;
+  pageInfo: PageInfo;
 };
 
 export type PageInfo = {
@@ -593,6 +609,8 @@ export type Post = {
 };
 
 export type PostFilter = {
+  AND?: InputMaybe<Array<InputMaybe<PostFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<PostFilter>>>;
   hash?: InputMaybe<Scalars['String']['input']>;
   hashType?: InputMaybe<Scalars['BigInt']['input']>;
   hashType_gt?: InputMaybe<Scalars['BigInt']['input']>;
@@ -665,36 +683,36 @@ export type PostFilter = {
 
 export type PostPage = {
   __typename?: 'PostPage';
-  items?: Maybe<Array<Post>>;
-  pageInfo?: Maybe<PageInfo>;
+  items: Array<Post>;
+  pageInfo: PageInfo;
 };
 
 export type Query = {
   __typename?: 'Query';
   adds?: Maybe<Adds>;
-  addss?: Maybe<AddsPage>;
+  addss: AddsPage;
   channel?: Maybe<Channel>;
   channelCounter?: Maybe<ChannelCounter>;
-  channelCounters?: Maybe<ChannelCounterPage>;
+  channelCounters: ChannelCounterPage;
   channelRoles?: Maybe<ChannelRoles>;
-  channelRoless?: Maybe<ChannelRolesPage>;
-  channels?: Maybe<ChannelPage>;
+  channelRoless: ChannelRolesPage;
+  channels: ChannelPage;
   item?: Maybe<Item>;
   itemCounter?: Maybe<ItemCounter>;
-  itemCounters?: Maybe<ItemCounterPage>;
+  itemCounters: ItemCounterPage;
   itemRoles?: Maybe<ItemRoles>;
-  itemRoless?: Maybe<ItemRolesPage>;
-  items?: Maybe<ItemPage>;
+  itemRoless: ItemRolesPage;
+  items: ItemPage;
   message?: Maybe<Message>;
-  messages?: Maybe<MessagePage>;
+  messages: MessagePage;
   post?: Maybe<Post>;
-  posts?: Maybe<PostPage>;
+  posts: PostPage;
   txn?: Maybe<Txn>;
-  txns?: Maybe<TxnPage>;
+  txns: TxnPage;
   user?: Maybe<User>;
   userCounter?: Maybe<UserCounter>;
-  userCounters?: Maybe<UserCounterPage>;
-  users?: Maybe<UserPage>;
+  userCounters: UserCounterPage;
+  users: UserPage;
 };
 
 
@@ -907,6 +925,8 @@ export type Txn = {
 };
 
 export type TxnFilter = {
+  AND?: InputMaybe<Array<InputMaybe<TxnFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<TxnFilter>>>;
   id?: InputMaybe<Scalars['String']['input']>;
   id_gt?: InputMaybe<Scalars['String']['input']>;
   id_gte?: InputMaybe<Scalars['String']['input']>;
@@ -919,8 +939,8 @@ export type TxnFilter = {
 
 export type TxnPage = {
   __typename?: 'TxnPage';
-  items?: Maybe<Array<Txn>>;
-  pageInfo?: Maybe<PageInfo>;
+  items: Array<Txn>;
+  pageInfo: PageInfo;
 };
 
 export type User = {
@@ -941,6 +961,8 @@ export type UserCounter = {
 };
 
 export type UserCounterFilter = {
+  AND?: InputMaybe<Array<InputMaybe<UserCounterFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<UserCounterFilter>>>;
   counter?: InputMaybe<Scalars['BigInt']['input']>;
   counter_gt?: InputMaybe<Scalars['BigInt']['input']>;
   counter_gte?: InputMaybe<Scalars['BigInt']['input']>;
@@ -971,11 +993,13 @@ export type UserCounterFilter = {
 
 export type UserCounterPage = {
   __typename?: 'UserCounterPage';
-  items?: Maybe<Array<UserCounter>>;
-  pageInfo?: Maybe<PageInfo>;
+  items: Array<UserCounter>;
+  pageInfo: PageInfo;
 };
 
 export type UserFilter = {
+  AND?: InputMaybe<Array<InputMaybe<UserFilter>>>;
+  OR?: InputMaybe<Array<InputMaybe<UserFilter>>>;
   from?: InputMaybe<Scalars['String']['input']>;
   from_gt?: InputMaybe<Scalars['String']['input']>;
   from_gte?: InputMaybe<Scalars['String']['input']>;
@@ -1028,8 +1052,8 @@ export type UserFilter = {
 
 export type UserPage = {
   __typename?: 'UserPage';
-  items?: Maybe<Array<User>>;
-  pageInfo?: Maybe<PageInfo>;
+  items: Array<User>;
+  pageInfo: PageInfo;
 };
 
 export type PageInfoFragment = { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasPreviousPage: boolean, hasNextPage: boolean };
@@ -1040,52 +1064,54 @@ export type AllAddsQueryVariables = Exact<{
 }>;
 
 
-export type AllAddsQuery = { __typename?: 'Query', addss?: { __typename?: 'AddsPage', items?: Array<{ __typename?: 'Adds', addedById: any, removed?: boolean | null, channelId: string, item: { __typename?: 'Item', id: string, timestamp: any, createdById: any, uri: string }, channel: { __typename?: 'Channel', name: string, roles?: { __typename?: 'ChannelRolesPage', items?: Array<{ __typename?: 'ChannelRoles', timestamp: any, rid: any, role: any }> | null } | null, adds?: { __typename?: 'AddsPage', items?: Array<{ __typename?: 'Adds', itemId: string }> | null } | null } }> | null, pageInfo?: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasPreviousPage: boolean, hasNextPage: boolean } | null } | null };
+export type AllAddsQuery = { __typename?: 'Query', addss: { __typename?: 'AddsPage', items: Array<{ __typename?: 'Adds', addedById: any, removed?: boolean | null, channelId: string, item: { __typename?: 'Item', id: string, timestamp: any, createdById: any, uri: string }, channel: { __typename?: 'Channel', name: string, roles?: { __typename?: 'ChannelRolesPage', items: Array<{ __typename?: 'ChannelRoles', timestamp: any, rid: any, role: any }> } | null, adds?: { __typename?: 'AddsPage', items: Array<{ __typename?: 'Adds', itemId: string }> } | null } }>, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasPreviousPage: boolean, hasNextPage: boolean } } };
 
 export type AllChannelsQueryVariables = Exact<{
   endCursor?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
-export type AllChannelsQuery = { __typename?: 'Query', channels?: { __typename?: 'ChannelPage', items?: Array<{ __typename?: 'Channel', id: string, timestamp: any, createdById: any, uri: string, name: string, description: string, roles?: { __typename?: 'ChannelRolesPage', items?: Array<{ __typename?: 'ChannelRoles', timestamp: any, rid: any, role: any }> | null } | null, adds?: { __typename?: 'AddsPage', items?: Array<{ __typename?: 'Adds', timestamp: any }> | null } | null }> | null, pageInfo?: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } | null } | null };
+export type AllChannelsQuery = { __typename?: 'Query', channels: { __typename?: 'ChannelPage', items: Array<{ __typename?: 'Channel', id: string, timestamp: any, createdById: any, uri: string, name: string, description: string, roles?: { __typename?: 'ChannelRolesPage', items: Array<{ __typename?: 'ChannelRoles', timestamp: any, rid: any, role: any }> } | null, adds?: { __typename?: 'AddsPage', items: Array<{ __typename?: 'Adds', timestamp: any }> } | null }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
 
 export type AllChannelsWithRidQueryVariables = Exact<{
   rid: Scalars['BigInt']['input'];
 }>;
 
 
-export type AllChannelsWithRidQuery = { __typename?: 'Query', channelRoless?: { __typename?: 'ChannelRolesPage', items?: Array<{ __typename?: 'ChannelRoles', channel: { __typename?: 'Channel', id: string, timestamp: any, createdById: any, uri: string, name: string, description: string, roles?: { __typename?: 'ChannelRolesPage', items?: Array<{ __typename?: 'ChannelRoles', rid: any, role: any }> | null } | null, adds?: { __typename?: 'AddsPage', items?: Array<{ __typename?: 'Adds', timestamp: any, channelId: string, itemId: string, addedById: any, removed?: boolean | null, item: { __typename?: 'Item', id: string, uri: string, timestamp: any, createdById: any } }> | null } | null } }> | null } | null };
+export type AllChannelsWithRidQuery = { __typename?: 'Query', channelRoless: { __typename?: 'ChannelRolesPage', items: Array<{ __typename?: 'ChannelRoles', channel: { __typename?: 'Channel', id: string, timestamp: any, createdById: any, uri: string, name: string, description: string, roles?: { __typename?: 'ChannelRolesPage', items: Array<{ __typename?: 'ChannelRoles', rid: any, role: any }> } | null, adds?: { __typename?: 'AddsPage', items: Array<{ __typename?: 'Adds', timestamp: any, channelId: string, itemId: string, addedById: any, removed?: boolean | null, item: { __typename?: 'Item', id: string, uri: string, timestamp: any, createdById: any } }> } | null } }> } };
 
 export type AllItemsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type AllItemsQuery = { __typename?: 'Query', items?: { __typename?: 'ItemPage', items?: Array<{ __typename?: 'Item', id: string }> | null } | null };
+export type AllItemsQuery = { __typename?: 'Query', items: { __typename?: 'ItemPage', items: Array<{ __typename?: 'Item', id: string }> } };
 
 export type AllUsersQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type AllUsersQuery = { __typename?: 'Query', users?: { __typename?: 'UserPage', items?: Array<{ __typename?: 'User', id: any }> | null } | null };
+export type AllUsersQuery = { __typename?: 'Query', users: { __typename?: 'UserPage', items: Array<{ __typename?: 'User', id: any }> } };
 
 export type ChannelWithIdQueryVariables = Exact<{
   id: Scalars['String']['input'];
+  limit: Scalars['Int']['input'];
+  after?: InputMaybe<Scalars['String']['input']>;
 }>;
 
 
-export type ChannelWithIdQuery = { __typename?: 'Query', channel?: { __typename?: 'Channel', id: string, timestamp: any, createdById: any, uri: string, name: string, description: string, roles?: { __typename?: 'ChannelRolesPage', items?: Array<{ __typename?: 'ChannelRoles', timestamp: any, rid: any, role: any }> | null } | null, adds?: { __typename?: 'AddsPage', items?: Array<{ __typename?: 'Adds', timestamp: any, channelId: string, itemId: string, addedById: any, removed?: boolean | null, item: { __typename?: 'Item', id: string, uri: string, timestamp: any, createdById: any }, channel: { __typename?: 'Channel', name: string, adds?: { __typename?: 'AddsPage', items?: Array<{ __typename?: 'Adds', itemId: string }> | null } | null } }> | null } | null } | null };
+export type ChannelWithIdQuery = { __typename?: 'Query', channel?: { __typename?: 'Channel', id: string, timestamp: any, createdById: any, uri: string, name: string, description: string, roles?: { __typename?: 'ChannelRolesPage', items: Array<{ __typename?: 'ChannelRoles', timestamp: any, rid: any, role: any }> } | null, adds?: { __typename?: 'AddsPage', items: Array<{ __typename?: 'Adds', timestamp: any, channelId: string, itemId: string, addedById: any, removed?: boolean | null, item: { __typename?: 'Item', id: string, uri: string, timestamp: any, createdById: any }, channel: { __typename?: 'Channel', name: string, adds?: { __typename?: 'AddsPage', items: Array<{ __typename?: 'Adds', itemId: string }> } | null } }>, pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasPreviousPage: boolean, hasNextPage: boolean } } | null } | null };
 
 export type ChannelsForItemQueryVariables = Exact<{
   id: Scalars['String']['input'];
 }>;
 
 
-export type ChannelsForItemQuery = { __typename?: 'Query', addss?: { __typename?: 'AddsPage', items?: Array<{ __typename?: 'Adds', channel: { __typename?: 'Channel', id: string, timestamp: any, uri: string, name: string, roles?: { __typename?: 'ChannelRolesPage', items?: Array<{ __typename?: 'ChannelRoles', rid: any, role: any }> | null } | null, adds?: { __typename?: 'AddsPage', items?: Array<{ __typename?: 'Adds', timestamp: any, channelId: string, itemId: string, addedById: any, removed?: boolean | null, item: { __typename?: 'Item', id: string, uri: string, timestamp: any, createdById: any } }> | null } | null } }> | null } | null };
+export type ChannelsForItemQuery = { __typename?: 'Query', addss: { __typename?: 'AddsPage', items: Array<{ __typename?: 'Adds', channel: { __typename?: 'Channel', id: string, timestamp: any, uri: string, name: string, roles?: { __typename?: 'ChannelRolesPage', items: Array<{ __typename?: 'ChannelRoles', rid: any, role: any }> } | null, adds?: { __typename?: 'AddsPage', items: Array<{ __typename?: 'Adds', timestamp: any, channelId: string, itemId: string, addedById: any, removed?: boolean | null, item: { __typename?: 'Item', id: string, uri: string, timestamp: any, createdById: any } }> } | null } }> } };
 
 export type ChannelsItemsWithUserQueryVariables = Exact<{
   userId: Scalars['BigInt']['input'];
 }>;
 
 
-export type ChannelsItemsWithUserQuery = { __typename?: 'Query', channels?: { __typename?: 'ChannelPage', items?: Array<{ __typename?: 'Channel', id: string, timestamp: any, name: string, description: string, createdById: any, roles?: { __typename?: 'ChannelRolesPage', items?: Array<{ __typename?: 'ChannelRoles', rid: any, role: any }> | null } | null, adds?: { __typename?: 'AddsPage', items?: Array<{ __typename?: 'Adds', timestamp: any, removed?: boolean | null, item: { __typename?: 'Item', uri: string } }> | null } | null }> | null } | null, items?: { __typename?: 'ItemPage', items?: Array<{ __typename?: 'Item', timestamp: any, uri: string }> | null } | null };
+export type ChannelsItemsWithUserQuery = { __typename?: 'Query', channels: { __typename?: 'ChannelPage', items: Array<{ __typename?: 'Channel', id: string, timestamp: any, name: string, description: string, createdById: any, roles?: { __typename?: 'ChannelRolesPage', items: Array<{ __typename?: 'ChannelRoles', rid: any, role: any }> } | null, adds?: { __typename?: 'AddsPage', items: Array<{ __typename?: 'Adds', timestamp: any, removed?: boolean | null, item: { __typename?: 'Item', uri: string } }> } | null }> }, items: { __typename?: 'ItemPage', items: Array<{ __typename?: 'Item', timestamp: any, uri: string }> } };
 
 export type ItemPageQueryVariables = Exact<{
   id: Scalars['String']['input'];
@@ -1104,7 +1130,7 @@ export type ItemWithIdQuery = { __typename?: 'Query', item?: { __typename?: 'Ite
 export type MarqueeDataQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MarqueeDataQuery = { __typename?: 'Query', userCounters?: { __typename?: 'UserCounterPage', items?: Array<{ __typename?: 'UserCounter', counter: any }> | null } | null, itemCounters?: { __typename?: 'ItemCounterPage', items?: Array<{ __typename?: 'ItemCounter', counter: any }> | null } | null, channelCounters?: { __typename?: 'ChannelCounterPage', items?: Array<{ __typename?: 'ChannelCounter', counter: any }> | null } | null };
+export type MarqueeDataQuery = { __typename?: 'Query', userCounters: { __typename?: 'UserCounterPage', items: Array<{ __typename?: 'UserCounter', counter: any }> }, itemCounters: { __typename?: 'ItemCounterPage', items: Array<{ __typename?: 'ItemCounter', counter: any }> }, channelCounters: { __typename?: 'ChannelCounterPage', items: Array<{ __typename?: 'ChannelCounter', counter: any }> } };
 
 export type TxnHashQueryVariables = Exact<{
   hash: Scalars['String']['input'];
@@ -1118,7 +1144,7 @@ export type UserIdQueryVariables = Exact<{
 }>;
 
 
-export type UserIdQuery = { __typename?: 'Query', users?: { __typename?: 'UserPage', items?: Array<{ __typename?: 'User', id: any, userId: any, to: string, recovery: string, from: string }> | null } | null };
+export type UserIdQuery = { __typename?: 'Query', users: { __typename?: 'UserPage', items: Array<{ __typename?: 'User', id: any, userId: any, to: string, recovery: string, from: string }> } };
 
 export const PageInfoFragmentDoc = gql`
     fragment PageInfo on PageInfo {
@@ -1256,7 +1282,7 @@ export const AllUsersDocument = gql`
 }
     `;
 export const ChannelWithIdDocument = gql`
-    query channelWithId($id: String!) {
+    query channelWithId($id: String!, $limit: Int!, $after: String) {
   channel(id: $id) {
     id
     timestamp
@@ -1271,7 +1297,7 @@ export const ChannelWithIdDocument = gql`
         role
       }
     }
-    adds(limit: 100, orderBy: "timestamp", orderDirection: "desc") {
+    adds(limit: $limit, orderBy: "timestamp", orderDirection: "desc", after: $after) {
       items {
         timestamp
         channelId
@@ -1293,10 +1319,13 @@ export const ChannelWithIdDocument = gql`
           }
         }
       }
+      pageInfo {
+        ...PageInfo
+      }
     }
   }
 }
-    `;
+    ${PageInfoFragmentDoc}`;
 export const ChannelsForItemDocument = gql`
     query channelsForItem($id: String!) {
   addss(where: {itemId: $id}) {


### PR DESCRIPTION
- **update channel w/ id query**
- **update channel w/ id getter**
- **wip**

--

Pushing this up so I don't lose the code, but going to try and first grab a more accurate number for the `ChannelDetails` component using a direct SQL query.

@ioeylim Do you have thoughts about how `PaginationControls` fits with the current placement of `ChannelDetails`? My first thought is that `ChannelDetails` gets moved somewhere to the top of the page such that the bottoms of both the index route and channel route are identical.

![CleanShot 2024-04-10 at 16 16 07@2x](https://github.com/1ifeworld/river/assets/37086973/4c147129-a1f0-4f54-9c0f-2a4f17f39f58)
