### PR TITLE
add inline script

### DIFF
--- a/apps/site/app/layout.tsx
+++ b/apps/site/app/layout.tsx
@@ -6,6 +6,7 @@ import '../styles/globals.css'
 import { sfMono } from './fonts/fonts'
 import { Providers } from './providers/providers'
 import NextTopLoader from 'nextjs-toploader'
+import Script from 'next/script'
 
 export const metadata: Metadata = {
   title: 'River',
@@ -21,6 +22,14 @@ export default function RootLayout({
     <html lang="en" className={`${sfMono.variable}`} suppressHydrationWarning>
       <body>
         <Providers>
+          <Script id="unregister-service-worker">
+            {`
+            navigator.serviceWorker.getRegistrations().then(registrations => {
+              for (const registration of registrations) {
+                  registration.unregister();
+              }
+            })`}
+          </Script>
           <Header />
           <NextTopLoader
             color="#B4B4B4"


### PR DESCRIPTION
The goal for this was to try and unregister the dormant Saturn service worker which was available at `saturn-sw.js` by not reinstantiating another service worker. The code I pulled for this can be found [here](https://arc.net/l/quote/wpvkmkew).

I don't believe this is an immediate fix in the sense that I believe it will still take 24 hours after a user revisits River for this unregistration process to completely take hold. I think we should see in a few days if this was effective or not, if not we can try another approach.